### PR TITLE
updated build.sh and meta.yaml for v0.21

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-if [[ 0 == 1 ]]; then
+if [[ 1 == 1 ]]; then
 
 cp ${BUILD_PREFIX}/share/aclocal/pkg.m4 m4/pkg.m4
 [[ -d release-tarball-src ]] && cp release-tarball-src/configure .
 [[ -f configure ]] && cp -f configure configure.orig.1
 
-./autogen.sh %SKIP_GNULIB%
+./autogen.sh --skip-gnulib 
 
 if [[ $(uname -o) == "Msys" ]] ; then
     export PREFIX="$LIBRARY_PREFIX_U"
@@ -59,6 +59,9 @@ if [[ $(uname -o) == "Msys" ]] ; then
     export CXXFLAGS=$(echo " $CXXFLAGS " |sed -e "s, [-/]GL ,,")
 
     autoreconf -vfi
+else
+    autoreconf -vfi
+    automake --add-missing
 fi
 
 [[ -f configure ]] && cp -f configure configure.orig.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "gettext" %}
-{% set version = "0.20.2" %}
-{% set sha256 = "b22b818e644c37f6e3d1643a1943c32c3a9bff726d601e53047d2682019ceaba" %}
+{% set version = "0.21.0" %}
+{% set pversion = "0.21" %}
+{% set sha256 = "d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192" %}
 {% set am_version = "1.15" %} #  keep synchronized with build.sh
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -23,11 +24,11 @@ source:
     git_depth: 0
 {% endif %}
   # Just so we get a configure to diff against.
-  - url: ftp://ftp.gnu.org/pub/gnu/gettext/gettext-{{ version }}.tar.xz
+  - url: https://ftp.gnu.org/pub/gnu/gettext/gettext-{{ pversion }}.tar.xz
     sha256: {{ sha256 }}
     folder: release-tarball-src
 {% else %}
-  - url: ftp://ftp.gnu.org/pub/gnu/gettext/gettext-{{ version }}.tar.xz
+  - url: https://ftp.gnu.org/pub/gnu/gettext/gettext-{{ pversion }}.tar.xz
     sha256: {{ sha256 }}
 {% endif %}
     patches:
@@ -82,6 +83,7 @@ requirements:
     - autoconf-archive                   # [not win]
     - make                               # [unix]
     - vs2015_win-64                      # [win]
+    - wget                               # [unix]
   host:
     - ncurses                            # [not win]
     - libiconv                           # [osx]


### PR DESCRIPTION
Updated build.sh and meta.yaml for v0.21

Enabled the config on the build script for autoreconf.
Fixed the --skip-gnulib flag to be linux compatible.
Added automake --add-missing


In meta.yaml, introduced "pversion" to follow the general version syntax  
